### PR TITLE
Fix fields method to follow airtable spec

### DIFF
--- a/api/src/main/java/dev/fuxing/airtable/AirtableApi.java
+++ b/api/src/main/java/dev/fuxing/airtable/AirtableApi.java
@@ -426,7 +426,7 @@ public class AirtableApi {
         @Override
         public AirtableTable.QuerySpec fields(List<String> fields) {
             for (int i = 0; i < fields.size(); i++) {
-                builder.setParameter("fields[" + i + "]", fields.get(i));
+                builder.setParameter("fields[]", fields.get(i));
             }
             return this;
         }


### PR DESCRIPTION
When adding `fields[21]` (more than 21 fields), airtable API throws an error such as:
```json
{
	"error": {
		"type": "INVALID_REQUEST_UNKNOWN",
		"message": "Invalid request: parameter validation failed. Check your request data."
	}
}
```
Don't ask me why this breaks airtable, but according to the airtable api docs, the list of fields params should only include the brackets, not a number. Here's an example from their docs:


> For example, to only return data from Event Name and Performers, send these two query parameters:
  `fields%5B%5D=Fieldname1&fields%5B%5D=Fieldname2`
   Note: %5B%5D may be omitted when specifying multiple fields, but must always be included when specifying only a single field.

Submitting the requests without the numeric indexes in the fields[] works fine with 21 or more fields in the list.